### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -37,11 +37,11 @@ jobs:
           - windows-latest
           - macos-latest
         deno_version:
-          - "1.43.x"
+          - "1.45.x"
           - "1.x"
         host_version:
-          - vim: "v9.1.0399"
-            nvim: "v0.9.5"
+          - vim: "v9.1.0448"
+            nvim: "v0.10.0"
 
     runs-on: ${{ matrix.runner }}
     steps:

--- a/lsputil/deps.ts
+++ b/lsputil/deps.ts
@@ -16,4 +16,4 @@ export {
   assertLess,
   assertRejects,
 } from "jsr:@std/assert@0.226.0";
-export { test } from "jsr:@denops/test@2.0.1";
+export { test } from "jsr:@denops/test@3.0.4";


### PR DESCRIPTION
This PR updates some dependencies to fix CI failures.

- Update `denops/test` module version to fix the following connection failure between deno and vim/nvim.

```
error: Error: [denops-test] Connection failed.
      throw new Error("[denops-test] Connection failed.", { cause });
            ^
    at getConn (https://jsr.io/@denops/test/2.0.1/with.ts:97:13)
    at eventLoopTick (ext:core/01_core.js:207:9)
    at async perform (https://jsr.io/@denops/test/2.0.1/with.ts:136:18)
    at async withDenops (https://jsr.io/@denops/test/2.0.1/with.ts:156:3)
Caused by: DeadlineError: Deadline
    at https://jsr.io/@std/async/0.224.0/deadline.ts:60:32
    at eventLoopTick (ext:core/01_core.js:207:9)
    at async getConn (https://jsr.io/@denops/test/2.0.1/with.ts:95:14)
    at async perform (https://jsr.io/@denops/test/2.0.1/with.ts:136:18)
    at async withDenops (https://jsr.io/@denops/test/2.0.1/with.ts:156:3)
```
Ref: https://github.com/uga-rosa/deno-denops-lsputil/actions/runs/11199886982/job/31132787816

- Update versions of deno/vim/nvim in CI to fulfill the requirements of the latest denops.vim.
   - Ref: https://github.com/vim-denops/denops.vim/blob/3a38e081f922e0134671236edd3e6dcbb251d10c/README.md